### PR TITLE
Escape numeric field names to comply to matlab structs

### DIFF
--- a/parsejson.m
+++ b/parsejson.m
@@ -121,7 +121,11 @@ function [obj, idx] = object(json, idx, str_tokens, num_tokens)
             end
             idx = next(json, idx);
             [v, idx] = value(json, idx, str_tokens, num_tokens);
-            obj.(k) = v;
+            if ~isletter(k(1))
+                obj.(['alpha__' k]) = v;
+            else
+                obj.(k) = v;
+            end
             idx = next(json, idx);
             if json(idx) == ','
                 idx = idx+1;


### PR DESCRIPTION
Since matlab only accepts struct fields to beginn with a letter, a arbitrary string `alpha__` is prefixed if the first character of a proposed field name is not a letter.
