### PR TITLE
Fixed zmq header for windows and library installation tips for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ INSTALLATION
    
    
    
-INSALLATION GUIDE FOR WINDOWS   
+INSTALLATION GUIDE FOR WINDOWS   
 -----------------------------
 
 * Install zeromq from here:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,38 @@ INSTALLATION
 
 5. If you indent to start Matlab on a remote computer, make sure that
    computer is reachable through SSH and fullfills the above steps.
+   
+   
+   
+INSALLATION GUIDE FOR WINDOWS   
+-----------------------------
+
+* Install zeromq from here:
+http://zeromq.org/distro:microsoft-windows
+"Stable Release 4.0.4" worked well for me.
+
+* Copy libzmq-v90-mt-4_0_4.dll into libzmq.dll
+
+* Make sure that matlab knows the path of this dll (I don't remember if I did this using the PATH env. variable, or by adding addpath('path/to/zeromq/bin') to matlabrc.m )
+
+* Put addpath('path/to/transplant_library') in matlabrc.m
+
+* Matlab doesn't always ship with a C/C++ compiler, In my case of Matlab 2014b x64 it didn't.
+Matlab needs a compiler in order to load and use the zeromq binary DLLs, which is a C++ library. Note that it's needed for using matlab "LoadLibrary" function to load any C/C++ DLL.
+
+* In the case that you don't have a compiler that Matlab knows, one of the options that you can do is download  Win 7 SDK.
+https://www.microsoft.com/en-us/download/details.aspx?id=8279
+Note that the sdk installer checks for .net framework 4, and in the likely case that you have a newer version it will not install.
+You can trick it into installing with some simple registry trickery (*remember to restore it back after the installation is complete*)
+Make sure that compilers are selected as a component to be installed.
+Look at the accepted answer here for the registry trickery:
+http://stackoverflow.com/questions/31455926/windows-sdk-setup-failure
+
+* Now, manually run a *new* Matlab session, and verify that you can manually use LoadLibrary('lib
+zmq.dll','transplantzmq.h') without getting any errors/warnings.
+
+* You are ready to go!
+   
 
 LICENSE
 -------

--- a/transplantzmq.h
+++ b/transplantzmq.h
@@ -1,5 +1,5 @@
 // from stddef.h:
-typedef long unsigned int size_t;
+//typedef long unsigned int size_t;
 
 // from zmq.h
 int zmq_errno (void);
@@ -17,4 +17,5 @@ void *zmq_msg_data (zmq_msg_t *msg);
 void *zmq_socket (void *, int type);
 int zmq_close (void *s);
 int zmq_connect (void *s, const char *addr);
-int zmq_send (void *s, const void *buf, size_t len, int flags);
+//int zmq_send (void *s, const void *buf, size_t len, int flags);
+int zmq_send (void *s, const void *buf, long unsigned len, int flags);


### PR DESCRIPTION
Fixed zmq header for windows and library installation tips for windows.

Notice that macros still need to be added to the header in order to choose different function declarations in linux/windows cases. This "transplantzmq.h" will work on windows but break linux.