### PR TITLE
fix parsing of int16 and negative fixnums in parsemsgpack.m

### DIFF
--- a/parsemsgpack.m
+++ b/parsemsgpack.m
@@ -110,7 +110,7 @@ function [obj, idx] = parse(bytes, idx)
         case 208 % int8
             obj = bytes2scalar(bytes(idx+1), 'int8');
             idx = idx+2;
-        case 208 % int16
+        case 209 % int16
             obj = bytes2scalar(bytes(idx+1:idx+2), 'int16');
             idx = idx+3;
         case 210 % int32

--- a/parsemsgpack.m
+++ b/parsemsgpack.m
@@ -40,7 +40,7 @@ function [obj, idx] = parse(bytes, idx)
         return
     elseif bitand(b11100000, currentbyte) == b11100000
         % decode negative fixint
-        obj = -bitand(b00011111, currentbyte);
+        obj = bytes2scalar(currentbyte, 'int8');
         idx = idx + 1;
         return
     elseif bitand(b11110000, currentbyte) == b10000000


### PR DESCRIPTION
For some reasons that I don't understand (i.e. unrelated changes), python's msgpack decided to encode the nargout=-1 as a negative fixnum (which I assume wasn't the case before or the bug should have happened sooner).

After some debugging I found out that the parsing of negative fixnums is broken in parsemsgpack.m and I also noticed that parsing of int16 doesn't work.
