### PR TITLE
Potentially fixes #39 crash on exit when using with IPython / Jupyter

### DIFF
--- a/transplant/transplant_master.py
+++ b/transplant/transplant_master.py
@@ -445,7 +445,9 @@ class Matlab(TransplantMaster):
                                  ['-r', '"transplant_remote {} {} {}"'
                                       .format(msgformat, zmq_address, "zmq")])
         self.msgformat = msgformat
-        self.context = zmq.Context.instance()
+        # Create a new ZMQ context instead of sharing the global ZMQ context.
+        # We now have ownership of it, and can terminate it with impunity.
+        self.context = zmq.Context()
         self.socket = self.context.socket(zmq.REQ)
         self.socket.bind(zmq_address)
         # start Matlab, but make sure that it won't eat the REPL stdin


### PR DESCRIPTION
From what I understand debugging around, Jupyter uses ZMQ as well, and, the exit functionality of transplant terminates the context, assuming it has complete ownership of it. An easy fix is to actually create an owned ZMQ context, which is what this change is. This fixes #39 that was reproing on Ubuntu  16.04 for me. Another possible fix is to not close the context, in which case, it should be automatically closed on garbage collection, but I have not tested such a change.