### PR TITLE
fix super() call in Matlab.exit

### DIFF
--- a/transplant/transplant_master.py
+++ b/transplant/transplant_master.py
@@ -572,7 +572,7 @@ class Matlab(TransplantMaster):
 
     def exit(self):
         """Close the connection, and kill the process."""
-        super(self.__class__, self).exit()
+        super().exit()
         self.socket.close()
         self.context.term()
 


### PR DESCRIPTION
Before, creating a subclass leads to a RecursionError on exit as `self.__class__` refers to the subclass instead of transplant.Matlab.

I am not sure if the current way of calling super was intentional and if there are side effects when just using `super()` without any arguments. It looks to me like something left from Python 2 times and everything still seems to work fine after the change.

Test script:
~~~py
import transplant

class Matlab(transplant.Matlab):
    pass

m = Matlab()
m.version()
~~~