### PR TITLE
ignore folders when checking for existance

### DIFF
--- a/transplant/transplant_remote.m
+++ b/transplant/transplant_remote.m
@@ -88,7 +88,9 @@ function transplant_remote(msgformat, url, zmqname, is_zombie)
                     % so that can't be used.
                     existance = evalin('base', ['exist(''' msg('name') ''')']);
                     % exist doesn't find methods, though.
-                    existance = existance | any(which(msg('name')));
+                    % exist returns 0 if the name does not exist and 7 if it is
+                    % a folder, which we are not interested in.
+                    existance = ~any(existance == [0, 7]) | any(which(msg('name')));
                     % value does not exist:
                     if ~existance
                         error('TRANSPLANT:novariable' , ...


### PR DESCRIPTION
throw TRANSPLANT:novariable if a variable is not defined but there is a
folder with the same name. this makes the handling of Matlab packages
in Matlab.__getattr__ work regardless of the current directory.

closes #81

I did not find any documentation on unit tests, but I ran `pytest` and got the same result (13 passed, 1 SparseEfficiencyWarning) before and after my change.