### PR TITLE
added a parameter "addpath" for Matlab()

### DIFF
--- a/transplant/transplant_master.py
+++ b/transplant/transplant_master.py
@@ -503,12 +503,14 @@ class Matlab(TransplantMaster):
         Whether to start Matlab with ``-nodesktop``, defaults to ``True``.
     jvm : bool
         Whether to start Matlab with ``-nojvm``, defaults to ``False``.
-
+    addpath : list
+        The paths of Matlab files to be added into Matlab path, defaults
+        to __file__.
     """
 
     ProxyObject = MatlabProxyObject
 
-    def __init__(self, executable='matlab', arguments=tuple(), msgformat='msgpack', address=None, user=None, print_to_stdout=True, desktop=False, jvm=True):
+    def __init__(self, executable='matlab', arguments=tuple(), msgformat='msgpack', address=None, user=None, print_to_stdout=True, desktop=False, jvm=True, addpath=list()):
         """Starts a Matlab instance and opens a communication channel."""
         if msgformat not in ['msgpack', 'json']:
             raise ValueError('msgformat must be "msgpack" or "json"')
@@ -523,6 +525,11 @@ class Matlab(TransplantMaster):
                 arguments += '-minimize',
         if not jvm and '-nojvm' not in arguments:
             arguments += '-nojvm',
+        paths = (os.path.dirname(__file__))
+        if addpath is not None:
+            for path in addpath:
+                tempath = str('\',\'' + path)
+                paths += tempath
 
         if address is None:
             if sys.platform == 'linux' or sys.platform == 'darwin':
@@ -538,7 +545,7 @@ class Matlab(TransplantMaster):
             process_arguments = ([executable] + list(arguments) +
                                  ['-r', "addpath('{}');cd('{}');"
                                   "transplant_remote('{}','{}','{}');".format(
-                                      os.path.dirname(__file__), os.getcwd(),
+                                      paths, os.getcwd(),
                                       msgformat, zmq_address, self._locate_libzmq()
 )])
         else:

--- a/transplant/transplant_master.py
+++ b/transplant/transplant_master.py
@@ -525,11 +525,8 @@ class Matlab(TransplantMaster):
                 arguments += '-minimize',
         if not jvm and '-nojvm' not in arguments:
             arguments += '-nojvm',
-        paths = (os.path.dirname(__file__))
-        if addpath is not None:
-            for path in addpath:
-                tempath = str('\',\'' + path)
-                paths += tempath
+        paths = [os.path.dirname(__file__)] + addpath
+        paths_string = ','.join("'{}'".format(p) for p in paths)
 
         if address is None:
             if sys.platform == 'linux' or sys.platform == 'darwin':
@@ -543,9 +540,9 @@ class Matlab(TransplantMaster):
                 zmq_address = 'tcp://127.0.0.1:' + str(port)
 
             process_arguments = ([executable] + list(arguments) +
-                                 ['-r', "addpath('{}');cd('{}');"
+                                 ['-r', "addpath({});cd('{}');"
                                   "transplant_remote('{}','{}','{}');".format(
-                                      paths, os.getcwd(),
+                                      paths_string, os.getcwd(),
                                       msgformat, zmq_address, self._locate_libzmq()
 )])
         else:


### PR DESCRIPTION
A parameter "addpath" was added to the Matlab() function to facilitate the settings of Matlab's path.

With this parameter, the Matlab files that always hide in the python project (Django, Tornado, etc.) can be added into the Matlab's path easily. Otherwise, we need to dig into the source code and add paths manually.